### PR TITLE
tox 4 upgrade

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -26,5 +26,5 @@ runs:
         pip install tox
       shell: bash
     - name: Run ${{ inputs.pipeline }} pipeline inside tox. Set tox.ini in your repo root to manage environment dependencies.
-      run: tox ${{ inputs.pipeline }}
+      run: tox -- ${{ inputs.pipeline }}
       shell: bash


### PR DESCRIPTION
As of tox 4, you HAVE to pass `--` at the cli to separate options to the test command. In the case of pypyr, this means instead of:

`$ tox ops/build package`

you have to run:
`$ tox -- ops/build package`

closes pypyr/pypyr#309.